### PR TITLE
add Does-it-build github action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,15 @@
+name: does-it-build
+on:
+    push:
+    pull_request:
+        branches: main
+
+jobs:
+  run-npm-build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '21'
+    - run: npm run build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,4 +12,10 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: '21'
-    - run: cd MuscleMate && npm run build
+
+    - name: Install dependencies
+      run: cd MuscleMate && npm install
+      working-directory: MuscleMate
+    - name: Build
+      run: npm run build
+      working-directory: MuscleMate

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,4 +12,4 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: '21'
-    - run: npm run build
+    - run: cd MuscleMate && npm run build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         node-version: '21'
 
     - name: Install dependencies
-      run: cd MuscleMate && npm install
+      run: npm install
       working-directory: MuscleMate
     - name: Build
       run: npm run build


### PR DESCRIPTION
no more dming rafid for vercel deployment faliures - you can now run npm build on the cloud and see the errors here